### PR TITLE
[Perf] Use SmallVec for some temporary allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,6 +2971,7 @@ version = "0.16.19"
 dependencies = [
  "bincode",
  "serde_json",
+ "smallvec",
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
  "zeroize",
@@ -3034,6 +3035,7 @@ dependencies = [
  "rayon",
  "rustc_version",
  "serde",
+ "smallvec",
  "snarkvm-fields",
  "snarkvm-utilities",
  "thiserror",

--- a/algorithms/src/crypto_hash/poseidon.rs
+++ b/algorithms/src/crypto_hash/poseidon.rs
@@ -464,7 +464,7 @@ impl<F: PrimeField, const RATE: usize> PoseidonSponge<F, RATE, 1> {
         };
         let bits = self.get_bits(num_bits_per_nonnative * num_elements);
 
-        let mut lookup_table = Vec::<TargetField>::with_capacity(num_bits_per_nonnative);
+        let mut lookup_table: SmallVec<[TargetField; 256]> = SmallVec::new();
         let mut cur = TargetField::one();
         for _ in 0..num_bits_per_nonnative {
             lookup_table.push(cur);

--- a/console/types/field/Cargo.toml
+++ b/console/types/field/Cargo.toml
@@ -14,6 +14,11 @@ version = "=0.16.19"
 path = "../boolean"
 version = "=0.16.19"
 
+[dependencies.smallvec]
+version = "1.11"
+features = [ "const_new" ]
+default-features = false
+
 [dependencies.zeroize]
 version = "1"
 features = [ "derive" ]

--- a/console/types/field/src/from_bits.rs
+++ b/console/types/field/src/from_bits.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use smallvec::{smallvec, SmallVec};
+
 impl<E: Environment> FromBits for Field<E> {
     /// Initializes a new field from a list of **little-endian** bits.
     ///   - If `bits_le` is longer than `E::Field::size_in_bits()`, the excess bits are enforced to be `0`s.
@@ -46,7 +48,7 @@ impl<E: Environment> FromBits for Field<E> {
             Ok(Field { field: E::Field::from_bigint(field).ok_or_else(|| anyhow!("Invalid field from bits"))? })
         } else {
             // Construct the sanitized list of bits padded with `false`
-            let mut sanitized_bits = vec![false; size_in_bits];
+            let mut sanitized_bits: SmallVec<[bool; 384]> = smallvec![false; size_in_bits];
             // Note: This is safe, because we just checked that the length of bits isn't bigger
             // than `size_in_data_bits` which is equal to `size_in_bits - 1`.
             sanitized_bits[..num_bits].copy_from_slice(bits_le);

--- a/curves/Cargo.toml
+++ b/curves/Cargo.toml
@@ -56,6 +56,11 @@ version = "1.0.188"
 default-features = false
 features = [ "derive" ]
 
+[dependencies.smallvec]
+version = "1.11"
+features = [ "const_new" ]
+default-features = false
+
 [dependencies.thiserror]
 version = "1.0"
 

--- a/curves/src/bls12_377/g1.rs
+++ b/curves/src/bls12_377/g1.rs
@@ -27,6 +27,7 @@ use crate::{
     ProjectiveCurve,
 };
 
+use smallvec::SmallVec;
 use std::ops::Neg;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -145,8 +146,8 @@ impl ShortWeierstrassParameters for Bls12_377G1Parameters {
             let d_mod_window_size = i64::try_from(d & MASK_FOR_MOD_TABLE_SIZE).unwrap();
             if d_mod_window_size >= HALF_TABLE_SIZE { d_mod_window_size - TABLE_SIZE } else { d_mod_window_size }
         };
-        let to_wnaf = |e: Self::ScalarField| -> Vec<i32> {
-            let mut naf = vec![];
+        let to_wnaf = |e: Self::ScalarField| -> SmallVec<[i32; 128]> {
+            let mut naf: SmallVec<[i32; 128]> = SmallVec::new();
             let mut e = e.to_bigint();
             while !e.is_zero() {
                 let next = if e.is_odd() {
@@ -167,7 +168,11 @@ impl ShortWeierstrassParameters for Bls12_377G1Parameters {
             naf
         };
 
-        let wnaf = |k1: Self::ScalarField, k2: Self::ScalarField, s1: bool, s2: bool| -> (Vec<i32>, Vec<i32>) {
+        let wnaf = |k1: Self::ScalarField,
+                    k2: Self::ScalarField,
+                    s1: bool,
+                    s2: bool|
+         -> (SmallVec<[i32; 128]>, SmallVec<[i32; 128]>) {
             let mut wnaf_1 = to_wnaf(k1);
             let mut wnaf_2 = to_wnaf(k2);
 


### PR DESCRIPTION
Temporary allocations are ones that are found to be deallocated directly after their creation, meaning they are suitable candidates for a substitution with an array (if the size is known in advance and `const`) or a `SmallVec`.

This PR applies the latter in two spots that were found to be a source of a significant number of temporary allocations, and the size was chosen based on values observed empirically in a `--dev` run.

More `SmallVec`-related changes will follow, but these 2 require no further setup.