### PR TITLE
Arced Program

### DIFF
--- a/ledger/block/src/transaction/deployment/bytes.rs
+++ b/ledger/block/src/transaction/deployment/bytes.rs
@@ -27,7 +27,7 @@ impl<N: Network> FromBytes for Deployment<N> {
         // Read the edition.
         let edition = u16::read_le(&mut reader)?;
         // Read the program.
-        let program = Program::read_le(&mut reader)?;
+        let program = Arc::new(Program::read_le(&mut reader)?);
 
         // Read the number of entries in the bundle.
         let num_entries = u16::read_le(&mut reader)?;

--- a/ledger/block/src/transaction/deployment/mod.rs
+++ b/ledger/block/src/transaction/deployment/mod.rs
@@ -27,12 +27,14 @@ use console::{
 use synthesizer_program::Program;
 use synthesizer_snark::{Certificate, VerifyingKey};
 
+use std::sync::Arc;
+
 #[derive(Clone, PartialEq, Eq)]
 pub struct Deployment<N: Network> {
     /// The edition.
     edition: u16,
     /// The program.
-    program: Program<N>,
+    program: Arc<Program<N>>,
     /// The mapping of function names to their verifying key and certificate.
     verifying_keys: Vec<(Identifier<N>, (VerifyingKey<N>, Certificate<N>))>,
 }
@@ -41,7 +43,7 @@ impl<N: Network> Deployment<N> {
     /// Initializes a new deployment.
     pub fn new(
         edition: u16,
-        program: Program<N>,
+        program: Arc<Program<N>>,
         verifying_keys: Vec<(Identifier<N>, (VerifyingKey<N>, Certificate<N>))>,
     ) -> Result<Self> {
         // Construct the deployment.
@@ -110,12 +112,12 @@ impl<N: Network> Deployment<N> {
     }
 
     /// Returns the program.
-    pub const fn program(&self) -> &Program<N> {
+    pub fn program(&self) -> &Arc<Program<N>> {
         &self.program
     }
 
     /// Returns the program.
-    pub const fn program_id(&self) -> &ProgramID<N> {
+    pub fn program_id(&self) -> &ProgramID<N> {
         self.program.id()
     }
 

--- a/ledger/block/src/transaction/mod.rs
+++ b/ledger/block/src/transaction/mod.rs
@@ -36,7 +36,7 @@ use console::{
 #[derive(Clone, PartialEq, Eq)]
 pub enum Transaction<N: Network> {
     /// The deploy transaction publishes an Aleo program to the network.
-    Deploy(N::TransactionID, ProgramOwner<N>, Box<Deployment<N>>, Fee<N>),
+    Deploy(N::TransactionID, ProgramOwner<N>, Deployment<N>, Fee<N>),
     /// The execute transaction represents a call to an Aleo program.
     Execute(N::TransactionID, Execution<N>, Option<Fee<N>>),
     /// The fee transaction represents a fee paid to the network, used for rejected transactions.
@@ -55,7 +55,7 @@ impl<N: Network> Transaction<N> {
         // Ensure the owner signed the correct transaction ID.
         ensure!(owner.verify(deployment_id), "Attempted to create a deployment transaction with an invalid owner");
         // Construct the deployment transaction.
-        Ok(Self::Deploy(id.into(), owner, Box::new(deployment), fee))
+        Ok(Self::Deploy(id.into(), owner, deployment, fee))
     }
 
     /// Initializes a new execution transaction.
@@ -126,7 +126,7 @@ impl<N: Network> Transaction<N> {
     #[inline]
     pub fn deployment(&self) -> Option<&Deployment<N>> {
         match self {
-            Self::Deploy(_, _, deployment, _) => Some(deployment.as_ref()),
+            Self::Deploy(_, _, deployment, _) => Some(deployment),
             _ => None,
         }
     }

--- a/ledger/block/src/transactions/rejected/mod.rs
+++ b/ledger/block/src/transactions/rejected/mod.rs
@@ -23,14 +23,14 @@ use crate::{Deployment, Execution, Fee};
 /// A wrapper around the rejected deployment or execution.
 #[derive(Clone, PartialEq, Eq)]
 pub enum Rejected<N: Network> {
-    Deployment(ProgramOwner<N>, Box<Deployment<N>>),
+    Deployment(ProgramOwner<N>, Deployment<N>),
     Execution(Execution<N>),
 }
 
 impl<N: Network> Rejected<N> {
     /// Initializes a rejected deployment.
     pub fn new_deployment(program_owner: ProgramOwner<N>, deployment: Deployment<N>) -> Self {
-        Self::Deployment(program_owner, Box::new(deployment))
+        Self::Deployment(program_owner, deployment)
     }
 
     /// Initializes a rejected execution.

--- a/ledger/query/src/query.rs
+++ b/ledger/query/src/query.rs
@@ -21,6 +21,8 @@ use console::{
 use ledger_store::{BlockStorage, BlockStore};
 use synthesizer_program::Program;
 
+use std::sync::Arc;
+
 #[derive(Clone)]
 pub enum Query<N: Network, B: BlockStorage<N>> {
     /// The block store from the VM.
@@ -142,7 +144,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
 
 impl<N: Network, B: BlockStorage<N>> Query<N, B> {
     /// Returns the program for the given program ID.
-    pub fn get_program(&self, program_id: &ProgramID<N>) -> Result<Program<N>> {
+    pub fn get_program(&self, program_id: &ProgramID<N>) -> Result<Arc<Program<N>>> {
         match self {
             Self::VM(block_store) => {
                 block_store.get_program(program_id)?.ok_or_else(|| anyhow!("Program {program_id} not found in storage"))
@@ -164,7 +166,7 @@ impl<N: Network, B: BlockStorage<N>> Query<N, B> {
 
     /// Returns the program for the given program ID.
     #[cfg(feature = "async")]
-    pub async fn get_program_async(&self, program_id: &ProgramID<N>) -> Result<Program<N>> {
+    pub async fn get_program_async(&self, program_id: &ProgramID<N>) -> Result<Arc<Program<N>>> {
         match self {
             Self::VM(block_store) => {
                 block_store.get_program(program_id)?.ok_or_else(|| anyhow!("Program {program_id} not found in storage"))

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use std::sync::Arc;
+
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Returns the committee for the given `block height`.
     pub fn get_committee(&self, block_height: u32) -> Result<Option<Committee<N>>> {
@@ -192,7 +194,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Returns the program for the given program ID.
-    pub fn get_program(&self, program_id: ProgramID<N>) -> Result<Program<N>> {
+    pub fn get_program(&self, program_id: ProgramID<N>) -> Result<Arc<Program<N>>> {
         match self.vm.block_store().get_program(&program_id)? {
             Some(program) => Ok(program),
             None => bail!("Missing program for ID {program_id}"),

--- a/ledger/src/iterators.rs
+++ b/ledger/src/iterators.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use std::sync::Arc;
+
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Returns an iterator over the state roots, for all blocks in `self`.
     pub fn state_roots(&self) -> impl '_ + Iterator<Item = Cow<'_, N::StateRoot>> {
@@ -33,7 +35,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Returns an iterator over the programs, for all transactions in `self`.
-    pub fn programs(&self) -> impl '_ + Iterator<Item = Cow<'_, Program<N>>> {
+    pub fn programs(&self) -> impl '_ + Iterator<Item = Cow<'_, Arc<Program<N>>>> {
         self.vm.transaction_store().programs()
     }
 

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -323,7 +323,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     pub fn create_deploy<R: Rng + CryptoRng>(
         &self,
         private_key: &PrivateKey<N>,
-        program: &Program<N>,
+        program: &Arc<Program<N>>,
         priority_fee_in_microcredits: u64,
         query: Option<Query<N, C::BlockStorage>>,
         rng: &mut R,

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -1291,7 +1291,7 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
     }
 
     /// Returns the program for the given `program ID`.
-    pub fn get_program(&self, program_id: &ProgramID<N>) -> Result<Option<Program<N>>> {
+    pub fn get_program(&self, program_id: &ProgramID<N>) -> Result<Option<Arc<Program<N>>>> {
         self.storage.transaction_store().get_program(program_id)
     }
 

--- a/ledger/store/src/helpers/memory/transaction.rs
+++ b/ledger/store/src/helpers/memory/transaction.rs
@@ -31,6 +31,8 @@ use console::{
 use synthesizer_program::Program;
 use synthesizer_snark::{Certificate, Proof, VerifyingKey};
 
+use std::sync::Arc;
+
 /// An in-memory transaction storage.
 #[derive(Clone)]
 pub struct TransactionMemory<N: Network> {
@@ -98,7 +100,7 @@ pub struct DeploymentMemory<N: Network> {
     /// The owner map.
     owner_map: MemoryMap<(ProgramID<N>, u16), ProgramOwner<N>>,
     /// The program map.
-    program_map: MemoryMap<(ProgramID<N>, u16), Program<N>>,
+    program_map: MemoryMap<(ProgramID<N>, u16), Arc<Program<N>>>,
     /// The verifying key map.
     verifying_key_map: MemoryMap<(ProgramID<N>, Identifier<N>, u16), VerifyingKey<N>>,
     /// The certificate map.
@@ -113,7 +115,7 @@ impl<N: Network> DeploymentStorage<N> for DeploymentMemory<N> {
     type EditionMap = MemoryMap<ProgramID<N>, u16>;
     type ReverseIDMap = MemoryMap<(ProgramID<N>, u16), N::TransactionID>;
     type OwnerMap = MemoryMap<(ProgramID<N>, u16), ProgramOwner<N>>;
-    type ProgramMap = MemoryMap<(ProgramID<N>, u16), Program<N>>;
+    type ProgramMap = MemoryMap<(ProgramID<N>, u16), Arc<Program<N>>>;
     type VerifyingKeyMap = MemoryMap<(ProgramID<N>, Identifier<N>, u16), VerifyingKey<N>>;
     type CertificateMap = MemoryMap<(ProgramID<N>, Identifier<N>, u16), Certificate<N>>;
     type FeeStorage = FeeMemory<N>;

--- a/ledger/store/src/helpers/rocksdb/transaction.rs
+++ b/ledger/store/src/helpers/rocksdb/transaction.rs
@@ -41,6 +41,8 @@ use console::{
 use synthesizer_program::Program;
 use synthesizer_snark::{Certificate, Proof, VerifyingKey};
 
+use std::sync::Arc;
+
 /// A database transaction storage.
 #[derive(Clone)]
 pub struct TransactionDB<N: Network> {
@@ -108,7 +110,7 @@ pub struct DeploymentDB<N: Network> {
     /// The program owner map.
     owner_map: DataMap<(ProgramID<N>, u16), ProgramOwner<N>>,
     /// The program map.
-    program_map: DataMap<(ProgramID<N>, u16), Program<N>>,
+    program_map: DataMap<(ProgramID<N>, u16), Arc<Program<N>>>,
     /// The verifying key map.
     verifying_key_map: DataMap<(ProgramID<N>, Identifier<N>, u16), VerifyingKey<N>>,
     /// The certificate map.
@@ -123,7 +125,7 @@ impl<N: Network> DeploymentStorage<N> for DeploymentDB<N> {
     type EditionMap = DataMap<ProgramID<N>, u16>;
     type ReverseIDMap = DataMap<(ProgramID<N>, u16), N::TransactionID>;
     type OwnerMap = DataMap<(ProgramID<N>, u16), ProgramOwner<N>>;
-    type ProgramMap = DataMap<(ProgramID<N>, u16), Program<N>>;
+    type ProgramMap = DataMap<(ProgramID<N>, u16), Arc<Program<N>>>;
     type VerifyingKeyMap = DataMap<(ProgramID<N>, Identifier<N>, u16), VerifyingKey<N>>;
     type CertificateMap = DataMap<(ProgramID<N>, Identifier<N>, u16), Certificate<N>>;
     type FeeStorage = FeeDB<N>;

--- a/ledger/store/src/transaction/deployment.rs
+++ b/ledger/store/src/transaction/deployment.rs
@@ -31,7 +31,7 @@ use synthesizer_snark::{Certificate, VerifyingKey};
 use aleo_std_storage::StorageMode;
 use anyhow::Result;
 use core::marker::PhantomData;
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::Arc};
 
 /// A trait for deployment storage.
 pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
@@ -44,7 +44,7 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
     /// The mapping of `(program ID, edition)` to `ProgramOwner`.
     type OwnerMap: for<'a> Map<'a, (ProgramID<N>, u16), ProgramOwner<N>>;
     /// The mapping of `(program ID, edition)` to `program`.
-    type ProgramMap: for<'a> Map<'a, (ProgramID<N>, u16), Program<N>>;
+    type ProgramMap: for<'a> Map<'a, (ProgramID<N>, u16), Arc<Program<N>>>;
     /// The mapping of `(program ID, function name, edition)` to `verifying key`.
     type VerifyingKeyMap: for<'a> Map<'a, (ProgramID<N>, Identifier<N>, u16), VerifyingKey<N>>;
     /// The mapping of `(program ID, function name, edition)` to `certificate`.
@@ -310,7 +310,7 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
     }
 
     /// Returns the program for the given `program ID`.
-    fn get_program(&self, program_id: &ProgramID<N>) -> Result<Option<Program<N>>> {
+    fn get_program(&self, program_id: &ProgramID<N>) -> Result<Option<Arc<Program<N>>>> {
         // Check if the program ID is for 'credits.aleo'.
         // This case is handled separately, as it is a default program of the VM.
         // TODO (howardwu): After we update 'fee' rules and 'Ratify' in genesis, we can remove this.
@@ -581,7 +581,7 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
     }
 
     /// Returns the program for the given `program ID`.
-    pub fn get_program(&self, program_id: &ProgramID<N>) -> Result<Option<Program<N>>> {
+    pub fn get_program(&self, program_id: &ProgramID<N>) -> Result<Option<Arc<Program<N>>>> {
         self.storage.get_program(program_id)
     }
 
@@ -646,7 +646,7 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
     }
 
     /// Returns an iterator over the programs, for all deployments.
-    pub fn programs(&self) -> impl '_ + Iterator<Item = Cow<'_, Program<N>>> {
+    pub fn programs(&self) -> impl '_ + Iterator<Item = Cow<'_, Arc<Program<N>>>> {
         self.storage.program_map().values_confirmed().map(|program| match program {
             Cow::Borrowed(program) => Cow::Borrowed(program),
             Cow::Owned(program) => Cow::Owned(program),

--- a/ledger/store/src/transaction/mod.rs
+++ b/ledger/store/src/transaction/mod.rs
@@ -39,7 +39,7 @@ use synthesizer_snark::{Certificate, VerifyingKey};
 use aleo_std_storage::StorageMode;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::Arc};
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TransactionType {
@@ -386,7 +386,7 @@ impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
     }
 
     /// Returns the program for the given `program ID`.
-    pub fn get_program(&self, program_id: &ProgramID<N>) -> Result<Option<Program<N>>> {
+    pub fn get_program(&self, program_id: &ProgramID<N>) -> Result<Option<Arc<Program<N>>>> {
         self.storage.deployment_store().get_program(program_id)
     }
 
@@ -458,7 +458,7 @@ impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
     }
 
     /// Returns an iterator over the programs, for all deployments.
-    pub fn programs(&self) -> impl '_ + Iterator<Item = Cow<'_, Program<N>>> {
+    pub fn programs(&self) -> impl '_ + Iterator<Item = Cow<'_, Arc<Program<N>>>> {
         self.storage.deployment_store().programs()
     }
 

--- a/ledger/test-helpers/src/lib.rs
+++ b/ledger/test-helpers/src/lib.rs
@@ -165,7 +165,7 @@ function compute:
 pub fn sample_rejected_deployment(is_fee_private: bool, rng: &mut TestRng) -> Rejected<CurrentNetwork> {
     // Sample a deploy transaction.
     let deployment = match crate::sample_deployment_transaction(is_fee_private, rng) {
-        Transaction::Deploy(_, _, deployment, _) => (*deployment).clone(),
+        Transaction::Deploy(_, _, deployment, _) => deployment.clone(),
         _ => unreachable!(),
     };
 

--- a/ledger/test-helpers/src/lib.rs
+++ b/ledger/test-helpers/src/lib.rs
@@ -39,6 +39,7 @@ use synthesizer_process::Process;
 use synthesizer_program::Program;
 
 use once_cell::sync::OnceCell;
+use std::sync::Arc;
 
 type CurrentNetwork = console::network::MainnetV0;
 type CurrentAleo = circuit::network::AleoV0;
@@ -147,6 +148,7 @@ function compute:
             )
             .unwrap();
             assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+            let program = Arc::new(program);
 
             // Construct the process.
             let process = Process::load().unwrap();
@@ -395,7 +397,7 @@ pub fn sample_large_execution_transaction(rng: &mut TestRng) -> Transaction<Curr
     let execution = INSTANCE
         .get_or_init(|| {
             // Initialize a program that produces large transactions.
-            let program = large_transaction_program();
+            let program = Arc::new(large_transaction_program());
 
             // Construct the process.
             let mut process = synthesizer_process::Process::load().unwrap();

--- a/synthesizer/process/src/deploy.rs
+++ b/synthesizer/process/src/deploy.rs
@@ -14,12 +14,14 @@
 
 use super::*;
 
+use std::sync::Arc;
+
 impl<N: Network> Process<N> {
     /// Deploys the given program ID, if it does not exist.
     #[inline]
     pub fn deploy<A: circuit::Aleo<Network = N>, R: Rng + CryptoRng>(
         &self,
-        program: &Program<N>,
+        program: &Arc<Program<N>>,
         rng: &mut R,
     ) -> Result<Deployment<N>> {
         let timer = timer!("Process::deploy");

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -117,7 +117,7 @@ impl<N: Network> Process<N> {
     /// Adds a new program to the process.
     /// If you intend to `execute` the program, use `deploy` and `finalize_deployment` instead.
     #[inline]
-    pub fn add_program(&mut self, program: &Program<N>) -> Result<()> {
+    pub fn add_program(&mut self, program: &Arc<Program<N>>) -> Result<()> {
         // Initialize the 'credits.aleo' program ID.
         let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
         // If the program is not 'credits.aleo', compute the program stack, and add it to the process.
@@ -223,7 +223,7 @@ impl<N: Network> Process<N> {
 
     /// Returns the program for the given program ID.
     #[inline]
-    pub fn get_program(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<&Program<N>> {
+    pub fn get_program(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<&Arc<Program<N>>> {
         Ok(self.get_stack(program_id)?.program())
     }
 

--- a/synthesizer/process/src/stack/helpers/initialize.rs
+++ b/synthesizer/process/src/stack/helpers/initialize.rs
@@ -17,7 +17,7 @@ use super::*;
 impl<N: Network> Stack<N> {
     /// Initializes a new stack, given the process and program.
     #[inline]
-    pub(crate) fn initialize(process: &Process<N>, program: &Program<N>) -> Result<Self> {
+    pub(crate) fn initialize(process: &Process<N>, program: &Arc<Program<N>>) -> Result<Self> {
         // Construct the stack for the program.
         let mut stack = Self {
             program: program.clone(),

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -88,6 +88,7 @@ use console::{
 };
 
 use indexmap::IndexMap;
+use std::sync::Arc;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 enum ProgramDefinition {
@@ -103,7 +104,7 @@ enum ProgramDefinition {
     Function,
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 pub struct ProgramCore<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> {
     /// The ID of the program.
     id: ProgramID<N>,
@@ -144,8 +145,8 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
 
     /// Initializes the credits program.
     #[inline]
-    pub fn credits() -> Result<Self> {
-        Self::from_str(include_str!("./resources/credits.aleo"))
+    pub fn credits() -> Result<Arc<Self>> {
+        Self::from_str(include_str!("./resources/credits.aleo")).map(Arc::new)
     }
 
     /// Returns the ID of the program.

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -60,7 +60,7 @@ pub trait StackMatches<N: Network> {
 
 pub trait StackProgram<N: Network> {
     /// Returns the program.
-    fn program(&self) -> &Program<N>;
+    fn program(&self) -> &Arc<Program<N>>;
 
     /// Returns the program ID.
     fn program_id(&self) -> &ProgramID<N>;
@@ -75,7 +75,7 @@ pub trait StackProgram<N: Network> {
     fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<&Arc<Self>>;
 
     /// Returns the external program for the given program ID.
-    fn get_external_program(&self, program_id: &ProgramID<N>) -> Result<&Program<N>>;
+    fn get_external_program(&self, program_id: &ProgramID<N>) -> Result<&Arc<Program<N>>>;
 
     /// Returns `true` if the stack contains the external record.
     fn get_external_record(&self, locator: &Locator<N>) -> Result<&RecordType<N>>;

--- a/synthesizer/src/vm/deploy.rs
+++ b/synthesizer/src/vm/deploy.rs
@@ -24,7 +24,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     pub fn deploy<R: Rng + CryptoRng>(
         &self,
         private_key: &PrivateKey<N>,
-        program: &Program<N>,
+        program: &Arc<Program<N>>,
         fee_record: Option<Record<N, Plaintext<N>>>,
         priority_fee_in_microcredits: u64,
         query: Option<Query<N, C::BlockStorage>>,
@@ -70,11 +70,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Returns a deployment for the given program.
     #[inline]
-    pub(super) fn deploy_raw<R: Rng + CryptoRng>(&self, program: &Program<N>, rng: &mut R) -> Result<Deployment<N>> {
+    pub(super) fn deploy_raw<R: Rng + CryptoRng>(&self, program: &Arc<Program<N>>, rng: &mut R) -> Result<Deployment<N>> {
         macro_rules! logic {
             ($process:expr, $network:path, $aleo:path) => {{
                 // Prepare the program.
-                let program = cast_ref!(&program as Program<$network>);
+                let program = cast_ref!(&program as Arc<Program<$network>>);
                 // Compute the deployment.
                 let deployment = $process.deploy::<$aleo, _>(program, rng)?;
                 // Prepare the deployment.

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -339,7 +339,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         // Check if the program has already been deployed in this block.
                         match deployments.contains(deployment.program_id()) {
                             // If the program has already been deployed, construct the rejected deploy transaction.
-                            true => match process_rejected_deployment(fee, *deployment.clone()) {
+                            true => match process_rejected_deployment(fee, deployment.clone()) {
                                 Ok(result) => result,
                                 Err(error) => {
                                     // Note: On failure, skip this transaction, and continue speculation.
@@ -361,7 +361,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                                         .map_err(|e| e.to_string())
                                 }
                                 // Construct the rejected deploy transaction.
-                                Err(_error) => match process_rejected_deployment(fee, *deployment.clone()) {
+                                Err(_error) => match process_rejected_deployment(fee, deployment.clone()) {
                                     Ok(result) => result,
                                     Err(error) => {
                                         // Note: On failure, skip this transaction, and continue speculation.

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -57,6 +57,7 @@ version = "1"
 [dependencies.serde]
 version = "1.0"
 default-features = false
+features = [ "rc" ]
 
 [dependencies.serde_json]
 version = "1.0"

--- a/vm/file/aleo.rs
+++ b/vm/file/aleo.rs
@@ -24,6 +24,7 @@ use std::{
     fs::{self, File},
     io::Write,
     path::Path,
+    sync::Arc,
 };
 
 static ALEO_FILE_EXTENSION: &str = "aleo";
@@ -34,7 +35,7 @@ pub struct AleoFile<N: Network> {
     /// The program as a string.
     program_string: String,
     /// The program.
-    program: Program<N>,
+    program: Arc<Program<N>>,
 }
 
 impl<N: Network> FromStr for AleoFile<N> {
@@ -43,7 +44,7 @@ impl<N: Network> FromStr for AleoFile<N> {
     /// Reads the file from a string.
     #[inline]
     fn from_str(s: &str) -> Result<Self> {
-        let program = Program::from_str(s)?;
+        let program = Arc::new(Program::from_str(s)?);
         let program_string = s.to_string();
 
         // The file name is defined as the string up to the extension (excluding the extension).
@@ -158,7 +159,7 @@ function hello:
     }
 
     /// Returns the program.
-    pub const fn program(&self) -> &Program<N> {
+    pub fn program(&self) -> &Arc<Program<N>> {
         &self.program
     }
 
@@ -230,7 +231,7 @@ impl<N: Network> AleoFile<N> {
         // Read the program string.
         let program_string = fs::read_to_string(file)?;
         // Parse the program string.
-        let program = Program::from_str(&program_string)?;
+        let program = Arc::new(Program::from_str(&program_string)?);
 
         Ok(Self { file_name, program_string, program })
     }

--- a/vm/file/avm.rs
+++ b/vm/file/avm.rs
@@ -22,6 +22,7 @@ use std::{
     fs::{self, File},
     io::Write,
     path::Path,
+    sync::Arc,
 };
 
 static AVM_FILE_EXTENSION: &str = "avm";
@@ -30,12 +31,12 @@ pub struct AVMFile<N: Network> {
     /// The file name (without the extension).
     file_name: String,
     /// The program.
-    program: Program<N>,
+    program: Arc<Program<N>>,
 }
 
 impl<N: Network> AVMFile<N> {
     /// Creates a new AVM program file, given the directory path, program ID, and `is_main` indicator.
-    pub fn create(directory: &Path, program: Program<N>, is_main: bool) -> Result<Self> {
+    pub fn create(directory: &Path, program: Arc<Program<N>>, is_main: bool) -> Result<Self> {
         // Ensure the directory path exists.
         ensure!(directory.exists(), "The program directory does not exist: '{}'", directory.display());
         // Ensure the program name is valid.
@@ -98,7 +99,7 @@ impl<N: Network> AVMFile<N> {
     }
 
     /// Returns the program.
-    pub const fn program(&self) -> &Program<N> {
+    pub const fn program(&self) -> &Arc<Program<N>> {
         &self.program
     }
 
@@ -152,7 +153,7 @@ impl<N: Network> AVMFile<N> {
         // Read the program bytes.
         let program_bytes = fs::read(file)?;
         // Parse the program bytes.
-        let program = Program::from_bytes_le(&program_bytes)?;
+        let program = Arc::new(Program::from_bytes_le(&program_bytes)?);
 
         Ok(Self { file_name, program })
     }

--- a/vm/package/build.rs
+++ b/vm/package/build.rs
@@ -14,17 +14,19 @@
 
 use super::*;
 
+use std::sync::Arc;
+
 use snarkvm_utilities::DeserializeExt;
 
 pub struct BuildRequest<N: Network> {
-    program: Program<N>,
-    imports: Vec<Program<N>>,
+    program: Arc<Program<N>>,
+    imports: Vec<Arc<Program<N>>>,
     function_name: Identifier<N>,
 }
 
 impl<N: Network> BuildRequest<N> {
     /// Initializes a new build request.
-    pub const fn new(program: Program<N>, imports: Vec<Program<N>>, function_name: Identifier<N>) -> Self {
+    pub const fn new(program: Arc<Program<N>>, imports: Vec<Arc<Program<N>>>, function_name: Identifier<N>) -> Self {
         Self { program, imports, function_name }
     }
 
@@ -34,12 +36,12 @@ impl<N: Network> BuildRequest<N> {
     }
 
     /// Returns the program.
-    pub const fn program(&self) -> &Program<N> {
+    pub fn program(&self) -> &Program<N> {
         &self.program
     }
 
     /// Returns the imports.
-    pub const fn imports(&self) -> &Vec<Program<N>> {
+    pub const fn imports(&self) -> &Vec<Arc<Program<N>>> {
         &self.imports
     }
 

--- a/vm/package/mod.rs
+++ b/vm/package/mod.rs
@@ -41,7 +41,10 @@ use crate::{
 use anyhow::{bail, ensure, Error, Result};
 use core::str::FromStr;
 use rand::{CryptoRng, Rng};
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 #[cfg(feature = "aleo-cli")]
 use colored::Colorize;
@@ -133,7 +136,7 @@ impl<N: Network> Package<N> {
     }
 
     /// Returns the program.
-    pub const fn program(&self) -> &Program<N> {
+    pub fn program(&self) -> &Arc<Program<N>> {
         self.program_file.program()
     }
 


### PR DESCRIPTION
In one of my ledger-load-only heap profiles the cloning of the `Program` (`ProgramCore<N, Instruction<N>, Command<N>>`) was quite prominent, meaning it could be a good candidate for `Arc`ing; such a change would also make the `Box`ing of the related `Deployment` superfluous, which would also contribute to a reduction in clones.

The clones of the `Program` are apparently also quite slow; even in a ledger where this change only results in a tiny change to the number of allocations, this speeds up its loading (via `Ledger::load`) by **~8%**.

I'm filing this PR as a draft for 2 reasons:
- I'm not _too_ happy about the `Map`-related type changes; while those would be an additional win for in-memory storage, I'm not convinced about the persistent one
- I'd like to perform profiling again with a larger storage, in order to double-check these findings; I will do so soon, when the current devnet's ledger grows larger